### PR TITLE
Add std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ categories = ["os", "no-std"]
 
 [dependencies]
 sgx_trts = { rev = "v1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk" }
+
+[features]
+std = []


### PR DESCRIPTION
Even in a no_std environment, a dependency error will occur if there is no mention of std in Cargo.toml.
